### PR TITLE
fix webpack-hot-middleware reloading/navigation issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,11 +34,12 @@ if (!inProduction) {
   const hotMiddleWare = require('webpack-hot-middleware')
   const webpackConf = require('@root/webpack.config')
   /* eslint-enable */
-  const compiler = webpack(webpackConf('development', { mode: 'development' }))
+  const config = webpackConf('development', { mode: 'development' })
+  const compiler = webpack(config)
 
   const devMiddleware = middleware(compiler)
   app.use(devMiddleware)
-  app.use(hotMiddleWare(compiler))
+  app.use(hotMiddleWare(compiler, { publicPath: config.output.publicPath }))
   app.use('*', (req, res, next) => {
     const filename = path.join(compiler.outputPath, 'index.html')
     devMiddleware.waitUntilValid(() => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,5 +72,8 @@ module.exports = (env, argv) => {
       }),
       ...additionalPlugins,
     ],
+    output: {
+      publicPath: '/'
+    }
   }
 }


### PR DESCRIPTION
Fixes issue where in dev mode, app will try to load "main.js" from locations other than the root. It causes "Unexpected token '<' Error" when reloading/navigating back/forwards from certain locations.